### PR TITLE
fix(agent-lab): add suport for seperated key for agent lab (#579)

### DIFF
--- a/.github/workflows/ai-assistant-deploy.yaml
+++ b/.github/workflows/ai-assistant-deploy.yaml
@@ -47,6 +47,7 @@ jobs:
         run: |
           yq eval ".image.tag = \"${VERSION}\"" -i ./infrastructure/k8s/helm/charts/${{ env.CHART_NAME }}/values.yaml
           yq eval ".env.OPENAI_API_KEY = \"${{ secrets.AI_ASSISTANT_OPENAI_API_KEY }}\"" -i ./infrastructure/k8s/helm/charts/${{ env.CHART_NAME }}/values.yaml
+          yq eval ".env.OPENAI_AGENT_API_KEY = \"${{ secrets.AI_ASSISTANT_OPENAI_AGENT_API_KEY }}\"" -i ./infrastructure/k8s/helm/charts/${{ env.CHART_NAME }}/values.yaml
           yq eval ".env.redis.password = \"${{ secrets.REDIS_PASSWORD }}\"" -i ./infrastructure/k8s/helm/charts/${{ env.CHART_NAME }}/values.yaml
           yq eval ".env.PG_PASSWORD = \"${{ secrets.PSQL_PASSWORD }}\"" -i ./infrastructure/k8s/helm/charts/${{ env.CHART_NAME }}/values.yaml
           yq eval ".env.CODE_REVIEW_MODEL = \"${{ vars.AI_ASSISTANT_MODEL }}\"" -i ./infrastructure/k8s/helm/charts/${{ env.CHART_NAME }}/values.yaml

--- a/app/ai-assistant/.env-tpl
+++ b/app/ai-assistant/.env-tpl
@@ -1,4 +1,6 @@
 OPENAI_API_KEY=
+# Separate API key for Agent Lab agent execution (tracked separately in OpenAI dashboard)
+OPENAI_AGENT_API_KEY=
 PORT=3001
 NODE_ENV=development
 # Valid values: local | development | production

--- a/app/ai-assistant/src/domain/services/OpenAIProxyService.ts
+++ b/app/ai-assistant/src/domain/services/OpenAIProxyService.ts
@@ -13,8 +13,12 @@ export class OpenAIProxyService {
         private tokenUsageService: TokenUsageService,
         private userAIKeyService: UserAIKeyService
     ) {
+        if (!process.env.OPENAI_AGENT_API_KEY) {
+            this.logger.warn('OPENAI_AGENT_API_KEY not set, falling back to OPENAI_API_KEY. Agent and assistant usage will not be tracked separately.');
+        }
+
         this.systemOpenAI = new OpenAI({
-            apiKey: process.env.OPENAI_API_KEY,
+            apiKey: process.env.OPENAI_AGENT_API_KEY || process.env.OPENAI_API_KEY,
         });
     }
 
@@ -71,7 +75,6 @@ export class OpenAIProxyService {
         if (!body.stream_options) {
             body.stream_options = { include_usage: true };
         }
-
 
         return await openaiClient.chat.completions.create(body, options) as AsyncIterable<any>;
     }

--- a/infrastructure/k8s/helm/charts/ai-assistant/templates/ai-assistant-dpl.yaml
+++ b/infrastructure/k8s/helm/charts/ai-assistant/templates/ai-assistant-dpl.yaml
@@ -42,6 +42,11 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-ai-assistant-secrets"
                   key: openai_api_key
+            - name: OPENAI_AGENT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-ai-assistant-secrets"
+                  key: openai_agent_api_key
             - name: INSTRUCTIONS_PATH
               value: "/config/instructions.txt"
             - name: CODE_REVIEW_MODEL

--- a/infrastructure/k8s/helm/charts/ai-assistant/templates/ai-assistant-secrets.yaml
+++ b/infrastructure/k8s/helm/charts/ai-assistant/templates/ai-assistant-secrets.yaml
@@ -6,4 +6,5 @@ type: Opaque
 data:
   psql_pwd: {{ .Values.env.PG_PASSWORD | b64enc }}
   openai_api_key: {{ .Values.env.OPENAI_API_KEY | b64enc }}
+  openai_agent_api_key: {{ .Values.env.OPENAI_AGENT_API_KEY | b64enc }}
   redis_password: {{ .Values.env.redis.password | b64enc }}

--- a/infrastructure/k8s/helm/charts/ai-assistant/values.yaml
+++ b/infrastructure/k8s/helm/charts/ai-assistant/values.yaml
@@ -19,6 +19,7 @@ env:
   PORT: "3001"
   HOST: "0.0.0.0"
   OPENAI_API_KEY: ""
+  OPENAI_AGENT_API_KEY: ""
   VECTOR_STORE_ID: "vs_688ceeab314c8191a557a849b28cf815"
   redis:
     host: valkey-cluster-portal-dev-do-user-4434163-0.i.db.ondigitalocean.com


### PR DESCRIPTION
Both AI Assistant and Agent Lab shared `OPENAI_API_KEY`, making it impossible to track usage separately in the OpenAI dashboard.

## Solution

New `OPENAI_AGENT_API_KEY` env variable dedicated to Agent Lab. Falls back to `OPENAI_API_KEY` if not set.

## Key Priority

| Priority | AI Assistant (`/chat`) | Agent Lab (`/openai/v1/*`) |
|----------|----------------------|---------------------------|
| 1 | User's BYOK key | User's BYOK key |
| 2 | `OPENAI_API_KEY` | `OPENAI_AGENT_API_KEY` |
| 3 | - | `OPENAI_API_KEY` (fallback) |

Resolve #579