### PR TITLE
Feat/local setup

### DIFF
--- a/app/playground-api/.dockerignore
+++ b/app/playground-api/.dockerignore
@@ -10,3 +10,8 @@ Dockerfile*
 README.md
 coverage
 .tmp
+
+docs/
+docker-compose.yaml
+docker-compose*.yml
+install_package_local.sh

--- a/app/playground-api/docker-compose.yaml
+++ b/app/playground-api/docker-compose.yaml
@@ -1,0 +1,43 @@
+# Local compose aligned with:
+# infrastructure/terraform/gcloud/app/playground-api/templates/playground/docker-compose.yaml
+# Image required: playground-api:latest-local (local tag only; no Artifact Registry path).
+# Build with Dockerfile (same runtimes as dev/prod via GCS packages). See docs/docker-local.md.
+
+services:
+  playground-api:
+    image: playground-api:latest-local
+    platform: linux/amd64
+    container_name: playground-api-local
+    restart: always
+    privileged: true
+    # Production maps 80:2000; 2000:2000 avoids binding privileged port 80 on the host for local use.
+    ports:
+      - "2000:2000"
+    environment:
+      COMPILE_CPU_TIME: 10000 # 10 seconds
+      COMPILE_MEMORY_LIMIT: 500000000 # 500 MB
+      COMPILE_TIMEOUT: 20000 # 20 seconds
+      DISABLE_NETWORKING: "false"
+      LOG_LEVEL: INFO
+      MAX_CONCURRENT_JOBS: 100
+      MAX_OPEN_FILES: 200
+      OUTPUT_MAX_SIZE: 102400 # 100 KB
+      # Leave PUBLIC_KEY unset for local dev so /api/playground/* does not require Bearer/session (do not expose without auth).
+      # PUBLIC_KEY: ca7fd8408500327b40d4da02dbc34881b2a379ccd3913a9d06e810a8fdb66329
+      RUN_CPU_TIME: 60000 # 60 seconds
+      RUN_MEMORY_LIMIT: 500000000 # 500 MB
+      RUN_TIMEOUT: 45000 # 45 seconds
+      MAX_FILE_SIZE: 20000000 # 20 MB
+    tmpfs:
+      - /tmp:exec
+    networks:
+      playground_net:
+        ipv4_address: 172.20.0.10
+
+networks:
+  playground_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1

--- a/app/playground-api/docker-compose.yaml
+++ b/app/playground-api/docker-compose.yaml
@@ -1,7 +1,7 @@
 # Local compose aligned with:
 # infrastructure/terraform/gcloud/app/playground-api/templates/playground/docker-compose.yaml
 # Image required: playground-api:latest-local (local tag only; no Artifact Registry path).
-# Build with Dockerfile (same runtimes as dev/prod via GCS packages). See docs/docker-local.md.
+# Build with Dockerfile (same runtimes as dev/prod via GCS packages). See docs/setup-local.md.
 
 services:
   playground-api:

--- a/app/playground-api/docs/configuration.md
+++ b/app/playground-api/docs/configuration.md
@@ -11,6 +11,17 @@ Level of log output to provide.
 
 One of `DEBUG`, `INFO`, `WARN`, `ERROR` or `NONE`
 
+## Public key (PASETO)
+
+```yaml
+key: PUBLIC_KEY
+default: (empty)
+```
+
+Hex-encoded 32-byte **public** key used to verify PASETO tokens from `Authorization: Bearer …` or the Hedera portal session cookie. Must be exactly 64 hex characters when set.
+
+When empty, auth middleware skips token checks for playground routes (not recommended outside local experiments).
+
 ## Bind Address
 
 ```yaml

--- a/app/playground-api/docs/setup-local.md
+++ b/app/playground-api/docs/setup-local.md
@@ -1,0 +1,82 @@
+# Run playground-api in Docker (local)
+
+This guide explains how to build the image with the main **`Dockerfile`** (Go, Java, Node, and Rust packages from the same URLs as dev/prod) and run it with `docker compose`, matching the GCE `docker-compose` layout (fixed network, `tmpfs`, environment variables, and a privileged container).
+
+## Requirements
+
+- Docker Desktop or Docker Engine with Compose v2.
+- Network access during **`docker build`** so layers can download runtime tarballs from `storage.googleapis.com`.
+
+## 1. Build the image
+
+The build context is **`app/playground-api`** (paths in `Dockerfile` are relative to that directory).
+
+From the monorepo root:
+
+```bash
+cd app/playground-api
+docker build --platform linux/amd64 -t playground-api:latest-local .
+```
+
+The tag matches the one used in this module’s `docker-compose.yaml`.
+
+## 2. Start the container
+
+From the same directory:
+
+```bash
+docker compose up
+```
+
+Detached:
+
+```bash
+docker compose up -d
+```
+
+## 3. Verify it responds
+
+By default this compose maps host **2000** to container **2000** (the Terraform template uses `80:2000`). Health is unauthenticated:
+
+```bash
+curl -sS http://127.0.0.1:2000/api/playground/health
+```
+
+`docker-compose.yaml` keeps **`PUBLIC_KEY` commented out** so the API behaves like an open local sandbox: `/api/playground/*` does not require a Bearer token or session cookie. Example:
+
+```bash
+curl -sS http://127.0.0.1:2000/api/playground/runtimes
+```
+
+To match deployed behaviour, uncomment `PUBLIC_KEY` in `docker-compose.yaml` and call the API with a valid **PASETO** `Authorization: Bearer …` (or portal session cookie) as in production.
+
+See [api-playground.md](api-playground.md) for API details and [configuration.md](configuration.md) for environment variables.
+
+## 4. Call `POST /api/playground/execute` (local)
+
+Against the compose in this repo the base URL is **`http://127.0.0.1:2000`**. With **`PUBLIC_KEY` unset**, `Accept` and `Content-Type` are enough; no `Authorization` header is required for local testing.
+
+```bash
+curl -sS 'http://127.0.0.1:2000/api/playground/execute' \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  --data '{"language":"javascript","version":"*","files":[{"content":"console.log(\"Hello World\");\n"}]}'
+```
+
+If you enable **`PUBLIC_KEY`** in `docker-compose.yaml`, add **`Authorization: Bearer <PASETO>`** (same as hedera portal).
+
+## 5. Stop and remove the stack
+
+From `app/playground-api` (same directory as `docker-compose.yaml`):
+
+```bash
+docker compose down
+```
+
+This stops the containers and removes the Compose project network. The image **`playground-api:latest-local`** remains on the Docker host until you delete it (for example with `docker rmi playground-api:latest-local`).
+
+## Notes
+
+- **`privileged: true`** and fixed IP `172.20.0.10` mirror the deployed environment; they are required for job isolation (`isolate`).
+- **`DISABLE_NETWORKING: "false"`** matches the deployment template so jobs may use the network. For stricter behavior (the in-code default is no network), set it to `"true"` in `docker-compose.yaml`.
+- Runtimes and checksums come from `Dockerfile` (`playground_pkgs_dev` URLs); that matches the dev/prod image contents, not `Dockerfile.local`.


### PR DESCRIPTION
## Summary

Adds a local **Docker Compose** stack for `playground-api` and a **setup guide** so developers can build the production-aligned image, run the API locally, exercise `/api/playground/execute`, and tear the stack down with `docker compose down`.

## Changes

- **`app/playground-api/docker-compose.yaml`**
  - Service aligned with the GCE Terraform template (privileged container, `tmpfs`, fixed bridge IP, env limits).
  - Local image tag **`playground-api:latest-local`** (no Artifact Registry path).
  - Host port **2000** → container **2000** (avoids binding host port 80).
  - **`PUBLIC_KEY` commented out** by default so local `/api/playground/*` does not require PASETO/session auth; uncomment to match deployed behaviour.

- **`app/playground-api/docs/setup-local.md`**
  - Build (`Dockerfile` from `app/playground-api`), `docker compose up` / `-d`, health check, `POST /api/playground/execute` examples, `docker compose down`.

- **`app/playground-api/docs/configuration.md`**
  - Documents **`PUBLIC_KEY`** (PASETO verification and behaviour when unset).

## How to test

1. `cd app/playground-api`
2. `docker build --platform linux/amd64 -t playground-api:latest-local .`
3. `docker compose up -d`
4. `curl -sS http://127.0.0.1:2000/api/playground/health`
5. `curl -sS http://127.0.0.1:2000/api/playground/runtimes` (no auth headers with default compose)
6. `docker compose down`

## Notes

- **Security:** Default compose is intended for **local use only** with `PUBLIC_KEY` unset; do not expose that configuration on the public internet without enabling auth or putting the API behind your own gateway.