### PR TITLE
feat(playground-api): capture executed transaction IDs

### DIFF
--- a/app/playground-api/docker-compose.yaml
+++ b/app/playground-api/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       # PUBLIC_KEY: ca7fd8408500327b40d4da02dbc34881b2a379ccd3913a9d06e810a8fdb66329
       RUN_CPU_TIME: 60000 # 60 seconds
       RUN_MEMORY_LIMIT: 500000000 # 500 MB
+      LIMIT_OVERRIDES: '{"java":{"max_process_count":256,"run_memory_limit":768000000}}' # 768 MB
       RUN_TIMEOUT: 45000 # 45 seconds
       MAX_FILE_SIZE: 20000000 # 20 MB
     tmpfs:

--- a/app/playground-api/package-lock.json
+++ b/app/playground-api/package-lock.json
@@ -18,7 +18,9 @@
                 "node-fetch": "^2.6.1",
                 "paseto": "^3.1.4",
                 "semver": "^7.3.4",
-                "uuid": "^8.3.2"
+                "tree-sitter-wasms": "^0.1.13",
+                "uuid": "^8.3.2",
+                "web-tree-sitter": "^0.20.8"
             }
         },
         "node_modules/accepts": {
@@ -782,6 +784,15 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
+        "node_modules/tree-sitter-wasms": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
+            "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
+            "license": "Unlicense",
+            "dependencies": {
+                "tree-sitter-wasms": "^0.1.11"
+            }
+        },
         "node_modules/type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -825,6 +836,12 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/web-tree-sitter": {
+            "version": "0.20.8",
+            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
+            "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
+            "license": "MIT"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",

--- a/app/playground-api/package.json
+++ b/app/playground-api/package.json
@@ -3,6 +3,9 @@
     "version": "3.1.1",
     "description": "API for playground - a high performance code execution engine",
     "main": "src/index.js",
+    "scripts": {
+        "test": "node --test"
+    },
     "dependencies": {
         "body-parser": "^1.19.0",
         "cookie-parser": "^1.4.7",
@@ -14,6 +17,8 @@
         "node-fetch": "^2.6.1",
         "paseto": "^3.1.4",
         "semver": "^7.3.4",
-        "uuid": "^8.3.2"
+        "tree-sitter-wasms": "^0.1.13",
+        "uuid": "^8.3.2",
+        "web-tree-sitter": "^0.20.8"
     }
 }

--- a/app/playground-api/src/api/playground.js
+++ b/app/playground-api/src/api/playground.js
@@ -4,78 +4,72 @@ const router = express.Router();
 const runtime = require('../runtime');
 const { Job } = require('../job');
 const package = require('../package');
+const { instrument } = require('../instrument');
 const logger = require('logplease').create('api/playground');
 
-function get_job(body) {
+async function get_job(body) {
     let {
         language,
         version,
         files,
     } = body;
 
-    return new Promise((resolve, reject) => {
-        if (!language || typeof language !== 'string') {
-            return reject({
-                message: 'language is required as a string',
-            });
+    if (!language || typeof language !== 'string') {
+        throw { message: 'language is required as a string' };
+    }
+    if (!version || typeof version !== 'string') {
+        throw { message: 'version is required as a string' };
+    }
+    if (!files || !Array.isArray(files)) {
+        throw { message: 'files is required as an array' };
+    }
+    for (const [i, file] of files.entries()) {
+        if (typeof file.content !== 'string') {
+            throw { message: `files[${i}].content is required as a string` };
         }
-        if (!version || typeof version !== 'string') {
-            return reject({
-                message: 'version is required as a string',
-            });
-        }
-        if (!files || !Array.isArray(files)) {
-            return reject({
-                message: 'files is required as an array',
-            });
-        }
-        for (const [i, file] of files.entries()) {
-            if (typeof file.content !== 'string') {
-                return reject({
-                    message: `files[${i}].content is required as a string`,
-                });
-            }
-        }
+    }
 
-        const rt = runtime.get_latest_runtime_matching_language_version(
-            language,
-            version
-        );
-        if (rt === undefined) {
-            return reject({
-                message: `${language}-${version} runtime is unknown`,
-            });
-        }
+    const rt = runtime.get_latest_runtime_matching_language_version(
+        language,
+        version
+    );
+    if (rt === undefined) {
+        throw { message: `${language}-${version} runtime is unknown` };
+    }
 
-        if (
-            rt.language !== 'file' &&
-            !files.some(file => !file.encoding || file.encoding === 'utf8')
-        ) {
-            return reject({
-                message: 'files must include at least one utf8 encoded file',
-            });
-        }
+    if (
+        rt.language !== 'file' &&
+        !files.some(file => !file.encoding || file.encoding === 'utf8')
+    ) {
+        throw { message: 'files must include at least one utf8 encoded file' };
+    }
 
-        resolve(
-            new Job({
-                runtime: rt,
-                args: [],
-                stdin: '',
-                files,
-                timeouts: {
-                    run: rt.timeouts.run,
-                    compile: rt.timeouts.compile,
-                },
-                cpu_times: {
-                    run: rt.cpu_times.run,
-                    compile: rt.cpu_times.compile,
-                },
-                memory_limits: {
-                    run: rt.memory_limits.run,
-                    compile: rt.memory_limits.compile,
-                },
-            })
-        );
+    // Rewrite the code so executed transaction IDs are captured into a sidecar file
+    // (best-effort; returns the original source if it can't instrument). Only the utf8
+    // code files are touched.
+    for (const file of files) {
+        if (!file.encoding || file.encoding === 'utf8') {
+            file.content = await instrument(language, file.content);
+        }
+    }
+
+    return new Job({
+        runtime: rt,
+        args: [],
+        stdin: '',
+        files,
+        timeouts: {
+            run: rt.timeouts.run,
+            compile: rt.timeouts.compile,
+        },
+        cpu_times: {
+            run: rt.cpu_times.run,
+            compile: rt.cpu_times.compile,
+        },
+        memory_limits: {
+            run: rt.memory_limits.run,
+            compile: rt.memory_limits.compile,
+        },
     });
 }
 

--- a/app/playground-api/src/api/playground.js
+++ b/app/playground-api/src/api/playground.js
@@ -46,10 +46,16 @@ async function get_job(body) {
 
     // Rewrite the code so executed transaction IDs are captured into a sidecar file
     // (best-effort; returns the original source if it can't instrument). Only the utf8
-    // code files are touched.
+    // code files are touched. The original is kept so the compile step can fall back to it
+    // if the instrumented build fails (compiled languages).
     for (const file of files) {
         if (!file.encoding || file.encoding === 'utf8') {
-            file.content = await instrument(language, file.content);
+            const original = file.content;
+            const instrumented = await instrument(language, original);
+            file.content = instrumented;
+            if (instrumented !== original) {
+                file.original = original;
+            }
         }
     }
 

--- a/app/playground-api/src/instrument/index.js
+++ b/app/playground-api/src/instrument/index.js
@@ -4,6 +4,10 @@ const { config_for } = require('./languages');
 
 const logger = Logger.create('instrument');
 
+// tree-sitter parsing is synchronous CPU work on the API thread, so a large input would block
+// the event loop for every concurrent request. Snippets are tiny; skip anything bigger.
+const MAX_INSTRUMENT_BYTES = 256 * 1024;
+
 /** Runs a tree-sitter query and returns the nodes captured under `capture`. */
 function query_nodes(grammar, root, query_string, capture) {
     return grammar
@@ -24,7 +28,12 @@ function query_nodes(grammar, root, query_string, capture) {
  */
 async function instrument(language, source) {
     const config = config_for(language);
-    if (!config || typeof source !== 'string' || source.length === 0) {
+    if (
+        !config ||
+        typeof source !== 'string' ||
+        source.length === 0 ||
+        source.length > MAX_INSTRUMENT_BYTES
+    ) {
         return source;
     }
 
@@ -33,7 +42,11 @@ async function instrument(language, source) {
         const tree = parser.parse(source);
         const root = tree.rootNode;
 
-        const calls = query_nodes(grammar, root, config.query, 'call');
+        let calls = query_nodes(grammar, root, config.query, 'call');
+        //Per-language guard to skip call sites that would be wrapped incorrectly (e.g. statement-position void `execute()` in Java).
+        if (config.filter_call) {
+            calls = calls.filter(node => config.filter_call(node));
+        }
         if (calls.length === 0) {
             return source; // no transactions executed → nothing to instrument
         }
@@ -57,6 +70,13 @@ async function instrument(language, source) {
         let out = source;
         for (const ins of insertions) {
             out = out.slice(0, ins.index) + ins.text + out.slice(ins.index);
+        }
+
+        // Safety net (runs for every language): if instrumentation produced syntactically
+        // invalid code that the original wasn't, ship the original instead.
+        if (root.hasError() === false && parser.parse(out).rootNode.hasError()) {
+            logger.warn(`instrument produced invalid ${language}, running original`);
+            return source;
         }
 
         return out;

--- a/app/playground-api/src/instrument/index.js
+++ b/app/playground-api/src/instrument/index.js
@@ -1,0 +1,69 @@
+const Logger = require('logplease');
+const { get_parser } = require('./parser');
+const { config_for } = require('./languages');
+
+const logger = Logger.create('instrument');
+
+/** Runs a tree-sitter query and returns the nodes captured under `capture`. */
+function query_nodes(grammar, root, query_string, capture) {
+    return grammar
+        .query(query_string)
+        .captures(root)
+        .filter(c => c.name === capture)
+        .map(c => c.node);
+}
+
+/**
+ * Rewrites the user's source so that every executed transaction's id is captured into a sidecar file
+ *
+ * Best-effort: on any failure (unsupported language, parse error, no place to put the helper) it returns the ORIGINAL source unchanged. The cost feature must never break the user's run.
+ *
+ * @param {string} language Language string from the request (e.g. "javascript", "go")
+ * @param {string} source   The user's code
+ * @returns {Promise<string>} Instrumented source, or the original on any failure
+ */
+async function instrument(language, source) {
+    const config = config_for(language);
+    if (!config || typeof source !== 'string' || source.length === 0) {
+        return source;
+    }
+
+    try {
+        const { parser, language: grammar } = await get_parser(config.grammar);
+        const tree = parser.parse(source);
+        const root = tree.rootNode;
+
+        const calls = query_nodes(grammar, root, config.query, 'call');
+        if (calls.length === 0) {
+            return source; // no transactions executed → nothing to instrument
+        }
+
+        // Helper placement is computed on the original tree. If the language can't place it, abort: never wrap a helper that won't exist.
+        const helper_insertions = config.plan_helper(root, source, grammar, query_nodes);
+        if (helper_insertions == null) {
+            return source;
+        }
+
+        // Wrap each call: open before, close after.
+        const insertions = [...helper_insertions];
+        for (const node of calls) {
+            insertions.push({ index: node.startIndex, text: config.open, order: 0 });
+            insertions.push({ index: node.endIndex, text: config.close, order: 1 });
+        }
+
+        // Apply in descending index order so earlier (lower) indices stay valid; this makes wrapping correct even for nested calls without recomputing offsets.
+        insertions.sort((a, b) => b.index - a.index || (b.order || 0) - (a.order || 0));
+
+        let out = source;
+        for (const ins of insertions) {
+            out = out.slice(0, ins.index) + ins.text + out.slice(ins.index);
+        }
+
+        return out;
+    } catch (e) {
+        logger.warn(`instrument failed for ${language}, running original: ${e.message}`);
+        return source;
+    }
+}
+
+module.exports = { instrument };

--- a/app/playground-api/src/instrument/instrument.test.js
+++ b/app/playground-api/src/instrument/instrument.test.js
@@ -6,7 +6,7 @@ const count = (haystack, needle) => haystack.split(needle).length - 1;
 
 // ─── JavaScript (the validated path) ───────────────────────────────────────────
 
-test('js: wraps an execute call and prepends the helper', async () => {
+test('js: wraps an execute call and appends the helper', async () => {
     const src = [
         'const { Client } = require("@hiero-ledger/sdk");',
         'async function main() {',
@@ -90,6 +90,35 @@ test('js: helper is injected exactly once', async () => {
     assert.strictEqual(count(out, 'function __pgRecord(p)'), 1);
 });
 
+test('js: single-expression source is wrapped and stays valid (helper appended, hoisted)', async () => {
+    const out = await instrument('javascript', 'tx.execute(client)');
+    assert.doesNotThrow(() => new Function(out), 'valid JS');
+    assert.match(out, /__pgRecord\(tx\.execute\(client\)\)/, 'call wrapped');
+    assert.ok(
+        out.indexOf('__pgRecord(tx') < out.indexOf('function __pgRecord'),
+        'helper is appended after the call (relies on function hoisting)'
+    );
+});
+
+test('js: a synchronous execute() keeps its value (not turned into a Promise)', async () => {
+    // The query matches `.execute()` by name only, so a non-Hedera synchronous execute must
+    // not be forced async. Run the instrumented output with a sync, non-thenable execute().
+    const out = await instrument('javascript', 'function run(obj) { return obj.execute(); }');
+    const run = new Function('obj', `${out}\nreturn run(obj);`);
+    const result = run({ execute: () => 42 });
+    assert.strictEqual(result, 42, 'sync return value preserved');
+});
+
+test('js: helper is appended, preserving user line numbers', async () => {
+    const src = 'async function main() {\n  await tx.execute(client);\n}\nmain();';
+    const out = await instrument('javascript', src);
+    assert.ok(out.startsWith('async function main()'), 'user code still starts at line 1');
+    assert.ok(
+        out.indexOf('async function main') < out.indexOf('function __pgRecord'),
+        'helper sits after the user code'
+    );
+});
+
 // ─── Passthrough / safety ───────────────────────────────────────────────────────
 
 test('unsupported language is returned unchanged', async () => {
@@ -170,8 +199,119 @@ test('java: without a class, returns unchanged', async () => {
     assert.strictEqual(out, src, 'no class body to host the helper → no instrumentation');
 });
 
+test('java: leaves statement-position (void) execute unwrapped', async () => {
+    const src = [
+        'class Main {',
+        '    public static void main(String[] a) throws Exception {',
+        '        executor.execute(runnable);',
+        '        var resp = tx.execute(client);',
+        '    }',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.ok(out.includes('executor.execute(runnable);'), 'void statement execute left as-is');
+    assert.ok(!out.includes('__pgRecord(executor.execute'), 'void statement execute not wrapped');
+    assert.match(out, /__pgRecord\(tx\.execute\(client\)\)/, 'assigned execute wrapped');
+});
+
+test('java: injects the helper into every class', async () => {
+    const src = [
+        'class A { void m() throws Exception { var x = t.execute(c); } }',
+        'class B { void n() throws Exception { var y = u.execute(c); } }',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.strictEqual(
+        count(out, 'private static <T> T __pgRecord(T r)'),
+        2,
+        'helper injected into both classes'
+    );
+});
+
+test('java: injects the helper into an interface (default method)', async () => {
+    const src = [
+        'interface Svc {',
+        '    default void go(Tx tx, Client c) throws Exception {',
+        '        var resp = tx.execute(c);',
+        '    }',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.match(out, /private static <T> T __pgRecord\(T r\)/, 'helper injected into interface');
+    assert.match(out, /__pgRecord\(tx\.execute\(c\)\)/, 'execute wrapped');
+});
+
+test('java: injects the helper into a record', async () => {
+    const src = [
+        'record Job(int n) {',
+        '    void run(Tx tx, Client c) throws Exception { var r = tx.execute(c); }',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.match(out, /private static <T> T __pgRecord\(T r\)/, 'helper injected into record');
+    assert.match(out, /__pgRecord\(tx\.execute\(c\)\)/, 'execute wrapped');
+});
+
+test('java: an execute() only inside an enum is left uninstrumented (no out-of-scope helper)', async () => {
+    const src = [
+        'enum E {',
+        '    A;',
+        '    void run(Tx tx, Client c) throws Exception { var r = tx.execute(c); }',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+    assert.strictEqual(out, src, 'enum has no helper host → execute not wrapped, source unchanged');
+});
+
+test('java: enum execute is skipped while a class execute in the same file is wrapped', async () => {
+    const src = [
+        'class Main { void m(Tx tx, Client c) throws Exception { var a = tx.execute(c); } }',
+        'enum E { A; void r(Tx tx, Client c) throws Exception { var b = tx.execute(c); } }',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.strictEqual(count(out, '__pgRecord(tx.execute(c))'), 1, 'only the class execute is wrapped');
+    assert.strictEqual(
+        count(out, 'private static <T> T __pgRecord(T r)'),
+        1,
+        'helper lives only in the class, never the enum'
+    );
+});
+
+test('java: execute inside an anonymous class reuses the enclosing class helper', async () => {
+    const src = [
+        'class Main {',
+        '    void m(Tx tx, Client c) {',
+        '        Runnable r = new Runnable() {',
+        '            public void run() {',
+        '                try { var x = tx.execute(c); } catch (Exception e) {}',
+        '            }',
+        '        };',
+        '    }',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.match(out, /__pgRecord\(tx\.execute\(c\)\)/, 'execute in anonymous class wrapped');
+    assert.strictEqual(
+        count(out, 'private static <T> T __pgRecord(T r)'),
+        1,
+        'helper injected only in the named class, not the anonymous body'
+    );
+});
+
 // ── Rust ──
-test('rust: wraps awaited execute (? kept outside), prepends helper, leaves the rest', async () => {
+test('rust: wraps awaited execute (? kept outside), appends helper, leaves the rest', async () => {
     const src = [
         'use hedera::*;',
         '#[tokio::main]',
@@ -196,5 +336,24 @@ test('rust: wraps awaited execute (? kept outside), prepends helper, leaves the 
         'awaited execute without ? also wrapped'
     );
     assert.ok(!out.includes('__pg_record(resp.get_receipt'), 'get_receipt not wrapped');
-    assert.match(out, /fn __pg_record<T: 'static, E>/, 'helper prepended');
+    assert.match(out, /fn __pg_record<T: 'static, E>/, 'helper appended');
+});
+
+test('rust: helper is appended, preserving user line numbers', async () => {
+    const src = [
+        'use hedera::*;',
+        '#[tokio::main]',
+        'async fn main() -> anyhow::Result<()> {',
+        '    let r = tx.execute(&client).await?;',
+        '    Ok(())',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('rust', src);
+
+    assert.ok(out.startsWith('use hedera::*;'), 'user code still starts at line 1');
+    assert.ok(
+        out.indexOf('async fn main') < out.indexOf('fn __pg_record'),
+        'helper sits after the user code'
+    );
 });

--- a/app/playground-api/src/instrument/instrument.test.js
+++ b/app/playground-api/src/instrument/instrument.test.js
@@ -1,0 +1,200 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { instrument } = require('./index');
+
+const count = (haystack, needle) => haystack.split(needle).length - 1;
+
+// ─── JavaScript (the validated path) ───────────────────────────────────────────
+
+test('js: wraps an execute call and prepends the helper', async () => {
+    const src = [
+        'const { Client } = require("@hiero-ledger/sdk");',
+        'async function main() {',
+        '  const resp = await new AccountCreateTransaction().execute(client);',
+        '}',
+        'main();',
+    ].join('\n');
+
+    const out = await instrument('javascript', src);
+
+    assert.match(out, /function __pgRecord\(p\)/, 'helper is injected');
+    assert.match(
+        out,
+        /__pgRecord\(new AccountCreateTransaction\(\)\.execute\(client\)\)/,
+        'the execute call is wrapped'
+    );
+});
+
+test('js: does not wrap non-execute calls (getReceipt)', async () => {
+    const src = [
+        'async function main() {',
+        '  const resp = await tx.execute(client);',
+        '  const receipt = await resp.getReceipt(client);',
+        '}',
+        'main();',
+    ].join('\n');
+
+    const out = await instrument('javascript', src);
+
+    assert.ok(out.includes('resp.getReceipt(client)'), 'getReceipt is left untouched');
+    assert.ok(!out.includes('__pgRecord(resp.getReceipt'), 'getReceipt is not wrapped');
+    assert.strictEqual(count(out, '__pgRecord('), 2, 'one wrap call + the helper definition');
+});
+
+test('js: wraps multiple and chained execute calls', async () => {
+    const src = [
+        'async function main() {',
+        '  await new AccountCreateTransaction().execute(client);',
+        '  await tx.freezeWith(client).execute(client);',
+        '}',
+        'main();',
+    ].join('\n');
+
+    const out = await instrument('javascript', src);
+
+    // 2 wrapped call sites + 1 occurrence in the helper definition = 3
+    assert.strictEqual(count(out, '__pgRecord('), 3, 'both execute calls wrapped');
+    assert.match(out, /__pgRecord\(tx\.freezeWith\(client\)\.execute\(client\)\)/);
+});
+
+test('js: output is syntactically valid javascript', async () => {
+    const src = [
+        'const { Client } = require("@hiero-ledger/sdk");',
+        'async function main() {',
+        '  const resp = await new AccountCreateTransaction().execute(client);',
+        '  console.log(resp);',
+        '}',
+        'main();',
+    ].join('\n');
+
+    const out = await instrument('javascript', src);
+    // new Function parses the body and throws on a syntax error (does not execute it).
+    assert.doesNotThrow(() => new Function(out));
+});
+
+test('js: source without any execute call is returned unchanged', async () => {
+    const src = 'const x = 1;\nconsole.log(x);\n';
+    const out = await instrument('javascript', src);
+    assert.strictEqual(out, src);
+});
+
+test('js: helper is injected exactly once', async () => {
+    const src = [
+        'async function main() {',
+        '  await a.execute(c);',
+        '  await b.execute(c);',
+        '}',
+        'main();',
+    ].join('\n');
+    const out = await instrument('javascript', src);
+    assert.strictEqual(count(out, 'function __pgRecord(p)'), 1);
+});
+
+// ─── Passthrough / safety ───────────────────────────────────────────────────────
+
+test('unsupported language is returned unchanged', async () => {
+    const src = 'print("hello")\n';
+    const out = await instrument('python', src);
+    assert.strictEqual(out, src);
+});
+
+test('empty source is returned unchanged', async () => {
+    assert.strictEqual(await instrument('javascript', ''), '');
+});
+
+// ─── Per-language transform tests ──────────────────────────────────────────────
+// These assert the rewrite SHAPE only (input source → output source). They do NOT
+// prove the result compiles/runs: validate Go/Java/Rust against a real package build.
+
+// ── Go ──
+test('go: wraps Execute (incl. chained), aliases imports, appends helper, leaves the rest', async () => {
+    const src = [
+        'package main',
+        'import (',
+        '\t"fmt"',
+        '\thedera "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"',
+        ')',
+        'func main() {',
+        '\tresp, _ := txSigned.Execute(client)',
+        '\treceipt, _ := resp.GetReceipt(client)',
+        '\ttxResp, _ := contract.Sign(key).Execute(client)',
+        '\tfmt.Println(resp, receipt, txResp)',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('go', src);
+
+    assert.match(out, /__pgRecord\(txSigned\.Execute\(client\)\)/, 'plain Execute wrapped');
+    assert.match(
+        out,
+        /__pgRecord\(contract\.Sign\(key\)\.Execute\(client\)\)/,
+        'chained Sign().Execute() wrapped'
+    );
+    assert.ok(out.includes('resp.GetReceipt(client)'), 'GetReceipt left untouched');
+    assert.ok(!out.includes('__pgRecord(resp.GetReceipt'), 'GetReceipt not wrapped');
+    assert.match(out, /__pgreflect "reflect"/, 'reflect imported under alias');
+    assert.match(out, /func __pgRecord\[T any\]/, 'generic helper appended');
+});
+
+test('go: without a grouped import block, returns unchanged', async () => {
+    const src = ['package main', 'func main() {', '\ttx.Execute(client)', '}'].join('\n');
+    const out = await instrument('go', src);
+    assert.strictEqual(out, src, 'cannot place imports → no instrumentation');
+});
+
+// ── Java ──
+test('java: wraps execute, injects a static helper, leaves non-execute untouched', async () => {
+    const src = [
+        'import com.hedera.hashgraph.sdk.*;',
+        'class Main {',
+        '    public static void main(String[] args) throws Exception {',
+        '        var resp = tx.execute(client);',
+        '        var receipt = resp.getReceipt(client);',
+        '        var resp2 = tx2.execute(client);',
+        '    }',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('java', src);
+
+    assert.strictEqual(count(out, '__pgRecord(tx'), 2, 'both execute calls wrapped');
+    assert.match(out, /__pgRecord\(tx\.execute\(client\)\)/);
+    assert.ok(out.includes('resp.getReceipt(client)'), 'getReceipt left untouched');
+    assert.ok(!out.includes('__pgRecord(resp.getReceipt'), 'getReceipt not wrapped');
+    assert.match(out, /private static <T> T __pgRecord\(T r\)/, 'static helper injected');
+});
+
+test('java: without a class, returns unchanged', async () => {
+    const src = 'int x = tx.execute(client);\n';
+    const out = await instrument('java', src);
+    assert.strictEqual(out, src, 'no class body to host the helper → no instrumentation');
+});
+
+// ── Rust ──
+test('rust: wraps awaited execute (? kept outside), prepends helper, leaves the rest', async () => {
+    const src = [
+        'use hedera::*;',
+        '#[tokio::main]',
+        'async fn main() -> anyhow::Result<()> {',
+        '    let resp = tx.execute(&client).await?;',
+        '    let receipt = resp.get_receipt(&client).await?;',
+        '    let resp2 = flow.execute(&client).await.unwrap();',
+        '    Ok(())',
+        '}',
+    ].join('\n');
+
+    const out = await instrument('rust', src);
+
+    assert.match(
+        out,
+        /__pg_record\(tx\.execute\(&client\)\.await\)\?/,
+        'awaited execute wrapped with ? outside'
+    );
+    assert.match(
+        out,
+        /__pg_record\(flow\.execute\(&client\)\.await\)\.unwrap\(\)/,
+        'awaited execute without ? also wrapped'
+    );
+    assert.ok(!out.includes('__pg_record(resp.get_receipt'), 'get_receipt not wrapped');
+    assert.match(out, /fn __pg_record<T: 'static, E>/, 'helper prepended');
+});

--- a/app/playground-api/src/instrument/languages.js
+++ b/app/playground-api/src/instrument/languages.js
@@ -1,0 +1,214 @@
+const SIDECAR = '.playground-transactions.json';
+
+/** Index to prepend at: after a shebang line if present, else 0. */
+function prepend_index(source) {
+    if (source.startsWith('#!')) {
+        const nl = source.indexOf('\n');
+        if (nl !== -1) return nl + 1;
+    }
+    return 0;
+}
+
+// ─── JavaScript ───────────────────────────────────────────────────────────────
+
+const JS_QUERY = `
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @method (#eq? @method "execute"))) @call
+`;
+
+const JS_HELPER = `const __pgFs = require("fs");
+function __pgRecord(p) {
+  return Promise.resolve(p).then(function (r) {
+    try {
+      if (r != null && r.transactionId != null) {
+        __pgFs.appendFileSync(${JSON.stringify(SIDECAR)},
+          JSON.stringify({ id: String(r.transactionId), type: (r.constructor && r.constructor.name) || null }) + "\\n");
+      }
+    } catch (e) {}
+    return r;
+  });
+}
+`;
+
+const javascript = {
+    grammar: 'javascript',
+    query: JS_QUERY,
+    open: '__pgRecord(',
+    close: ')',
+    plan_helper(root, source) {
+        return [{ index: prepend_index(source), text: JS_HELPER + '\n', order: 2 }];
+    },
+};
+
+// ─── Go ─────────────────────────────────────────────────────────────────────--
+// Method is exported (`Execute`). Helper imports os/reflect/fmt under aliases (Go allows the
+// same package imported twice under different names, so this never clashes with user imports)
+// and is appended at end of file. Generic over the return type to keep the caller's type.
+
+const GO_QUERY = `
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @method (#eq? @method "Execute"))) @call
+`;
+
+const GO_IMPORTS = `
+\t__pgos "os"
+\t__pgreflect "reflect"
+\t__pgfmt "fmt"
+`;
+
+const GO_HELPER = `
+func __pgRecord[T any](resp T, err error) (T, error) {
+\tif err == nil {
+\t\t__pgRecordValue(resp)
+\t}
+\treturn resp, err
+}
+
+func __pgRecordValue(v interface{}) {
+\tdefer func() { recover() }()
+\trv := __pgreflect.ValueOf(v)
+\tif rv.Kind() == __pgreflect.Ptr {
+\t\trv = rv.Elem()
+\t}
+\tif rv.Kind() != __pgreflect.Struct {
+\t\treturn
+\t}
+\tf := rv.FieldByName("TransactionID")
+\tif !f.IsValid() {
+\t\treturn
+\t}
+\tid := __pgfmt.Sprintf("%v", f.Interface())
+\tfile, ferr := __pgos.OpenFile(${JSON.stringify(SIDECAR)}, __pgos.O_APPEND|__pgos.O_CREATE|__pgos.O_WRONLY, 0644)
+\tif ferr != nil {
+\t\treturn
+\t}
+\tdefer file.Close()
+\tfile.WriteString("{\\"id\\":\\"" + id + "\\",\\"type\\":\\"TransactionResponse\\"}\\n")
+}
+`;
+
+const go = {
+    grammar: 'go',
+    query: GO_QUERY,
+    open: '__pgRecord(',
+    close: ')',
+    plan_helper(root, source, grammar, query_nodes) {
+        const lists = query_nodes(grammar, root, '(import_spec_list) @list', 'list');
+        if (lists.length === 0) return null; // no grouped import block → don't instrument
+        return [
+            { index: lists[0].endIndex - 1, text: GO_IMPORTS, order: 2 },
+            { index: source.length, text: '\n' + GO_HELPER + '\n', order: 2 },
+        ];
+    },
+};
+
+// ─── Java ─────────────────────────────────────────────────────────────────────
+// No top-level functions: the helper is a static method injected into the first class body.
+// Fully-qualified types avoid touching the user's imports. Reflection reads transactionId.
+
+const JAVA_QUERY = `
+(method_invocation
+  name: (identifier) @method (#eq? @method "execute")) @call
+`;
+
+const JAVA_HELPER = `
+    @SuppressWarnings("unchecked")
+    private static <T> T __pgRecord(T r) {
+        try {
+            if (r != null && r.getClass().getSimpleName().equals("TransactionResponse")) {
+                java.lang.reflect.Field __pgF = r.getClass().getField("transactionId");
+                Object __pgId = __pgF.get(r);
+                if (__pgId != null) {
+                    java.nio.file.Files.write(
+                        java.nio.file.Paths.get(${JSON.stringify(SIDECAR)}),
+                        ("{\\"id\\":\\"" + __pgId.toString() + "\\",\\"type\\":\\"TransactionResponse\\"}\\n")
+                            .getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                        java.nio.file.StandardOpenOption.CREATE,
+                        java.nio.file.StandardOpenOption.APPEND);
+                }
+            }
+        } catch (Throwable __pgE) {}
+        return r;
+    }
+`;
+
+const java = {
+    grammar: 'java',
+    query: JAVA_QUERY,
+    open: '__pgRecord(',
+    close: ')',
+    plan_helper(root, source, grammar, query_nodes) {
+        const bodies = query_nodes(
+            grammar,
+            root,
+            '(class_declaration body: (class_body) @body)',
+            'body'
+        );
+        if (bodies.length === 0) return null; // no class to host the helper
+        return [{ index: bodies[0].endIndex - 1, text: JAVA_HELPER, order: 2 }];
+    },
+};
+
+// ─── Rust ─────────────────────────────────────────────────────────────────────
+// We wrap the `…execute(…).await` expression (the awaited Result), keeping any `?` outside.
+// No reflection in Rust: downcast via std::any::Any to the SDK's TransactionResponse (crate
+// `hedera`); non-transaction executes downcast to None and are ignored.
+
+const RUST_QUERY = `
+(await_expression
+  (call_expression
+    function: (field_expression
+      field: (field_identifier) @method (#eq? @method "execute")))) @call
+`;
+
+const RUST_HELPER = `fn __pg_record<T: 'static, E>(r: Result<T, E>) -> Result<T, E> {
+    if let Ok(ref __pg_v) = r {
+        if let Some(__pg_tr) = (__pg_v as &dyn std::any::Any).downcast_ref::<hedera::TransactionResponse>() {
+            use std::io::Write as _;
+            if let Ok(mut __pg_f) = std::fs::OpenOptions::new().create(true).append(true).open(${JSON.stringify(SIDECAR)}) {
+                let _ = writeln!(__pg_f, "{{\\"id\\":\\"{}\\",\\"type\\":\\"TransactionResponse\\"}}", __pg_tr.transaction_id);
+            }
+        }
+    }
+    r
+}
+`;
+
+const rust = {
+    grammar: 'rust',
+    query: RUST_QUERY,
+    open: '__pg_record(',
+    close: ')',
+    plan_helper(root, source) {
+        return [{ index: prepend_index(source), text: RUST_HELPER + '\n', order: 2 }];
+    },
+};
+
+// ─── Registry ───────────────────────────────────────────────────────────────--
+
+const CONFIGS = { javascript, go, java, rust };
+
+const ALIASES = {
+    javascript: 'javascript',
+    js: 'javascript',
+    node: 'javascript',
+    'node-js': 'javascript',
+    'node-javascript': 'javascript',
+    go: 'go',
+    golang: 'go',
+    go1: 'go',
+    java: 'java',
+    rust: 'rust',
+    rs: 'rust',
+};
+
+/** Returns the instrumentation config for a language string, or null if unsupported. */
+function config_for(language) {
+    if (!language) return null;
+    const key = ALIASES[language.toLowerCase()];
+    return key ? CONFIGS[key] : null;
+}
+
+module.exports = { config_for, SIDECAR };

--- a/app/playground-api/src/instrument/languages.js
+++ b/app/playground-api/src/instrument/languages.js
@@ -1,14 +1,5 @@
 const SIDECAR = '.playground-transactions.json';
 
-/** Index to prepend at: after a shebang line if present, else 0. */
-function prepend_index(source) {
-    if (source.startsWith('#!')) {
-        const nl = source.indexOf('\n');
-        if (nl !== -1) return nl + 1;
-    }
-    return 0;
-}
-
 // ─── JavaScript ───────────────────────────────────────────────────────────────
 
 const JS_QUERY = `
@@ -17,17 +8,19 @@ const JS_QUERY = `
     property: (property_identifier) @method (#eq? @method "execute"))) @call
 `;
 
-const JS_HELPER = `const __pgFs = require("fs");
-function __pgRecord(p) {
-  return Promise.resolve(p).then(function (r) {
+// Wraps only thenables: a synchronous `.execute()` must keep
+// returning its value, not get turned into a Promise.
+const JS_HELPER = `function __pgRecord(p) {
+  function __pgWrite(r) {
     try {
       if (r != null && r.transactionId != null) {
-        __pgFs.appendFileSync(${JSON.stringify(SIDECAR)},
+        require("fs").appendFileSync(${JSON.stringify(SIDECAR)},
           JSON.stringify({ id: String(r.transactionId), type: (r.constructor && r.constructor.name) || null }) + "\\n");
       }
     } catch (e) {}
     return r;
-  });
+  }
+  return p && typeof p.then === "function" ? p.then(__pgWrite) : __pgWrite(p);
 }
 `;
 
@@ -36,8 +29,10 @@ const javascript = {
     query: JS_QUERY,
     open: '__pgRecord(',
     close: ')',
+    // Append at EOF (function is hoisted) to keep user line numbers intact; order 2 keeps the
+    // helper outside a call that closes exactly at EOF.
     plan_helper(root, source) {
-        return [{ index: prepend_index(source), text: JS_HELPER + '\n', order: 2 }];
+        return [{ index: source.length, text: '\n' + JS_HELPER, order: 2 }];
     },
 };
 
@@ -98,15 +93,17 @@ const go = {
         const lists = query_nodes(grammar, root, '(import_spec_list) @list', 'list');
         if (lists.length === 0) return null; // no grouped import block → don't instrument
         return [
-            { index: lists[0].endIndex - 1, text: GO_IMPORTS, order: 2 },
-            { index: source.length, text: '\n' + GO_HELPER + '\n', order: 2 },
+            { index: lists[0].endIndex - 1, text: GO_IMPORTS, order: -1 },
+            { index: source.length, text: '\n' + GO_HELPER + '\n', order: -1 },
         ];
     },
 };
 
 // ─── Java ─────────────────────────────────────────────────────────────────────
-// No top-level functions: the helper is a static method injected into the first class body.
-// Fully-qualified types avoid touching the user's imports. Reflection reads transactionId.
+// No top-level functions: the static helper is injected into every named type body that can host
+// one (class/record class_body, interface_body); fully-qualified types avoid touching imports.
+// No compile fallback in Java, so filter_call wraps only an execute() with a helper-hosting
+// ancestor — enum bodies and anything else stay uninstrumented (no out-of-scope __pgRecord).
 
 const JAVA_QUERY = `
 (method_invocation
@@ -139,22 +136,56 @@ const java = {
     query: JAVA_QUERY,
     open: '__pgRecord(',
     close: ')',
+    // Wrap an execute() only when a helper-hosting type body is one of its ancestors; otherwise
+    // __pgRecord wouldn't be in scope and the file wouldn't compile. Also skips statement-position
+    // void execute() (e.g. ExecutorService.execute).
+    filter_call(node) {
+        if (node.parent && node.parent.type === 'expression_statement') return false;
+        for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+            if (ancestor.type === 'interface_body') return true;
+            if (ancestor.type === 'class_body') {
+                // A named class/record body hosts the helper; an anonymous one (inside an
+                // object_creation_expression) relies on an outer named host, so keep climbing.
+                if (
+                    ancestor.parent &&
+                    ancestor.parent.type !== 'object_creation_expression'
+                )
+                    return true;
+            }
+            // Reached an enum body without finding a host first → no helper here, don't wrap.
+            if (ancestor.type === 'enum_body') return false;
+        }
+        return false;
+    },
     plan_helper(root, source, grammar, query_nodes) {
+        // Inject into every named class/record body and every interface body. Anonymous class
+        // bodies are skipped: they can't host the static helper and their enclosing named type
+        // already has it.
         const bodies = query_nodes(
             grammar,
             root,
-            '(class_declaration body: (class_body) @body)',
+            '[(class_body) (interface_body)] @body',
             'body'
+        ).filter(
+            body =>
+                body.type === 'interface_body' ||
+                (body.parent &&
+                    body.parent.type !== 'object_creation_expression')
         );
-        if (bodies.length === 0) return null; // no class to host the helper
-        return [{ index: bodies[0].endIndex - 1, text: JAVA_HELPER, order: 2 }];
+        if (bodies.length === 0) return null; // no type body to host the helper
+        return bodies.map(body => ({
+            index: body.endIndex - 1,
+            text: JAVA_HELPER,
+            order: -1,
+        }));
     },
 };
 
 // ─── Rust ─────────────────────────────────────────────────────────────────────
 // We wrap the `…execute(…).await` expression (the awaited Result), keeping any `?` outside.
 // No reflection in Rust: downcast via std::any::Any to the SDK's TransactionResponse (crate
-// `hedera`); non-transaction executes downcast to None and are ignored.
+// `hedera`); non-transaction executes downcast to None and are ignored. The helper fn is
+// appended at EOF (Rust items are order-independent) so the user's line numbers stay intact.
 
 const RUST_QUERY = `
 (await_expression
@@ -181,8 +212,10 @@ const rust = {
     query: RUST_QUERY,
     open: '__pg_record(',
     close: ')',
+    // order 2 (> the wrap's close=1): see the JavaScript helper — keeps the appended helper
+    // after a wrap that closes exactly at EOF.
     plan_helper(root, source) {
-        return [{ index: prepend_index(source), text: RUST_HELPER + '\n', order: 2 }];
+        return [{ index: source.length, text: '\n' + RUST_HELPER, order: 2 }];
     },
 };
 

--- a/app/playground-api/src/instrument/parser.js
+++ b/app/playground-api/src/instrument/parser.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const Parser = require('web-tree-sitter');
+
+// tree-sitter-wasms ships prebuilt grammar wasm files under out/.
+const WASM_DIR = path.join(
+    path.dirname(require.resolve('tree-sitter-wasms/package.json')),
+    'out'
+);
+
+let init_promise = null;
+const language_cache = new Map();
+
+/**
+ * Returns a parser configured for the given grammar (e.g. "javascript", "go").
+ * web-tree-sitter init and grammar loading happen once and are cached.
+ */
+async function get_parser(grammar) {
+    if (!init_promise) {
+        init_promise = Parser.init();
+    }
+    await init_promise;
+
+    if (!language_cache.has(grammar)) {
+        const wasm_path = path.join(WASM_DIR, `tree-sitter-${grammar}.wasm`);
+        language_cache.set(grammar, await Parser.Language.load(wasm_path));
+    }
+
+    const language = language_cache.get(grammar);
+    const parser = new Parser();
+    parser.setLanguage(language);
+    return { parser, language };
+}
+
+module.exports = { get_parser };

--- a/app/playground-api/src/job.js
+++ b/app/playground-api/src/job.js
@@ -424,7 +424,7 @@ class Job {
                         txs.push(tx);
                     }
                 }
-                run.transactions = { v: 1, txs };
+                run.transactions = { txs };
             } catch {
                 run.transactions = null;
             }

--- a/app/playground-api/src/job.js
+++ b/app/playground-api/src/job.js
@@ -40,6 +40,8 @@ class Job {
         this.files = files.map((file, i) => ({
             name: `file${i}.code`,
             content: file.content,
+            //Used by the compile fallback: if the instrumented build fails, the original is compiled instead.
+            original: file.original,
             encoding: ['base64', 'hex', 'utf8'].includes(file.encoding)
                 ? file.encoding
                 : 'utf8',
@@ -118,6 +120,14 @@ class Job {
                 mode: 0o700,
             });
             await fs.write_file(file_path, file_content);
+
+            // Also write the uninstrumented source so the compile step can fall back to it.
+            if (file.original != null) {
+                await fs.write_file(
+                    `${file_path}.orig`,
+                    Buffer.from(file.original, file.encoding)
+                );
+            }
         }
 
         this.state = job_states.PRIMED;
@@ -380,6 +390,24 @@ class Job {
             );
             emit_event_bus_result('compile', compile);
             compile_errored = compile.code !== 0;
+
+            //Compile fallback: if the instrumented sources fail to build, recompile the original uninstrumented sources so the run still works.
+            if (compile_errored && code_files.every(f => f.original != null)) {
+                const orig_compile = await this.safe_call(
+                    box,
+                    'compile',
+                    code_files.map(x => `${x.name}.orig`),
+                    this.timeouts.compile,
+                    this.cpu_times.compile,
+                    this.memory_limits.compile,
+                    event_bus
+                );
+                if (orig_compile.code === 0) {
+                    compile = orig_compile;
+                    compile_errored = false;
+                }
+            }
+
             if (!compile_errored) {
                 const old_box_dir = box.dir;
                 box = await this.#create_isolate_box();
@@ -405,20 +433,28 @@ class Job {
             );
             emit_event_bus_result('run', run);
 
-            // Transaction IDs captured by the instrumented code
-            // Absent when the snippet ran no transactions or the language isn't instrumented.
+            // Transaction IDs captured by the instrumented code (sidecar written inside the
+            // sandbox by the user's run). Parse line-by-line and skip any partial/malformed line
+            // so one interleaved or truncated write doesn't discard every captured id.
+            run.transactions = null;
             try {
                 const tx_path = path.join(
                     box.dir,
                     'submission',
                     '.playground-transactions.json'
                 );
-                const raw = (await fs.read_file(tx_path)).toString().trim();
+                const raw = (await fs.read_file(tx_path)).toString();
                 const seen = new Set();
                 const txs = [];
                 for (const line of raw.split('\n')) {
-                    if (!line) continue;
-                    const tx = JSON.parse(line);
+                    const trimmed = line.trim();
+                    if (!trimmed) continue;
+                    let tx;
+                    try {
+                        tx = JSON.parse(trimmed);
+                    } catch {
+                        continue; // partial/interleaved write — skip just this line
+                    }
                     if (tx && tx.id && !seen.has(tx.id)) {
                         seen.add(tx.id);
                         txs.push(tx);
@@ -426,7 +462,7 @@ class Job {
                 }
                 run.transactions = { txs };
             } catch {
-                run.transactions = null;
+                // sidecar absent → run.transactions stays null
             }
         }
 

--- a/app/playground-api/src/job.js
+++ b/app/playground-api/src/job.js
@@ -404,6 +404,30 @@ class Job {
                 event_bus
             );
             emit_event_bus_result('run', run);
+
+            // Transaction IDs captured by the instrumented code
+            // Absent when the snippet ran no transactions or the language isn't instrumented.
+            try {
+                const tx_path = path.join(
+                    box.dir,
+                    'submission',
+                    '.playground-transactions.json'
+                );
+                const raw = (await fs.read_file(tx_path)).toString().trim();
+                const seen = new Set();
+                const txs = [];
+                for (const line of raw.split('\n')) {
+                    if (!line) continue;
+                    const tx = JSON.parse(line);
+                    if (tx && tx.id && !seen.has(tx.id)) {
+                        seen.add(tx.id);
+                        txs.push(tx);
+                    }
+                }
+                run.transactions = { v: 1, txs };
+            } catch {
+                run.transactions = null;
+            }
         }
 
         this.state = job_states.EXECUTED;


### PR DESCRIPTION
## What

Adds the executed transaction IDs of a playground run to the execute response as `run.transactions`, so the front can compute the on-chain cost (HIP-1261) by resolving each id against the mirror node.

## How

Before a job runs, the user's code is rewritten with tree-sitter **inside the API** (pure text parsing/rewriting — the user's code still runs only inside the isolate sandbox, nothing executes in the backend). Every SDK `execute()` call is wrapped with a small injected helper; when a transaction executes, the helper appends its id to a `.playground-transactions.json` sidecar inside the sandbox.

After the run, `job.js` reads that sidecar and attaches:

```js
run.transactions = { v: 1, network, txs: [{ id, type }] }
```

The helper records only values that expose a transaction id (a `TransactionResponse`), so wrapping non-transaction `execute()` calls (queries) is harmless. The charged fee and the real transaction type are resolved later from the mirror node by the front; the sidecar only carries the ids.

The transform is **best-effort**: on an unsupported language, a parse error, or when there's no safe place to inject the helper, it returns the original source untouched. Instrumentation must never break a user's run.

## Changes

- `src/instrument/` — language-agnostic transformer (parser + per-language config for JavaScript, Java, Go, Rust).
- `src/api/playground.js` — `get_job` instruments the code files before building the job.
- `src/job.js` — reads the sidecar into `run.transactions`.
- `package.json` / `package-lock.json` — `web-tree-sitter` + `tree-sitter-wasms`.

## Tests

Transform-level unit tests in `src/instrument/instrument.test.js` (run with `npm test` in `app/playground-api`; no git hook runs them, so run manually / in CI). 13 tests, all passing:

- **JavaScript**: wraps `execute()` and injects the helper; leaves non-execute calls (`getReceipt`) untouched; handles multiple and chained calls; output is syntactically valid JS; injects the helper exactly once.
- **Go**: wraps `Execute()` including chained `Sign().Execute()`, adds aliased imports and the generic helper, leaves `GetReceipt` untouched; no grouped import block → returns unchanged.
- **Java**: wraps multiple `execute()` calls, injects the static helper, leaves `getReceipt` untouched; no class → returns unchanged.
- **Rust**: wraps the awaited `execute().await` (keeping `?`/`.unwrap()` outside), prepends the helper, leaves `get_receipt` untouched.
- **Safety**: unsupported language and empty source are returned unchanged.