### PR TITLE
fix(playground-api): rename compile-fallback sources

### DIFF
--- a/app/playground-api/src/job.js
+++ b/app/playground-api/src/job.js
@@ -122,9 +122,11 @@ class Job {
             await fs.write_file(file_path, file_content);
 
             // Also write the uninstrumented source so the compile step can fall back to it.
+            // Named fileN.orig (not fileN.code.orig): rustc derives the crate name from the
+            // file stem, and a stem with a dot ("file0.code") is an invalid crate name.
             if (file.original != null) {
                 await fs.write_file(
-                    `${file_path}.orig`,
+                    file_path.replace(/\.code$/, '.orig'),
                     Buffer.from(file.original, file.encoding)
                 );
             }
@@ -396,7 +398,7 @@ class Job {
                 const orig_compile = await this.safe_call(
                     box,
                     'compile',
-                    code_files.map(x => `${x.name}.orig`),
+                    code_files.map(x => x.name.replace(/\.code$/, '.orig')),
                     this.timeouts.compile,
                     this.cpu_times.compile,
                     this.memory_limits.compile,


### PR DESCRIPTION
## What

  The Rust compile fallback could never succeed: rustc derives the crate name from the file stem, and the fallback file "file0.code.orig" yields the stem "file0.code" — an invalid crate name (contains a dot). The fallback now writes "fileN.orig" instead, which both Rust and Go accept.

  ## Why

  When instrumented Rust fails to build (e.g. a user-defined execute() whose return type doesn't match the helper), the job is supposed to recompile the original source so the run still works. With the old name that recovery always failed and the user saw the instrumented compile error.

  ## Testing

  - Verified against the real package compile scripts inside the image: file0.code.orig fails ("invalid character '.' in crate name"), fileN.orig builds in both Rust and Go.
  - End-to-end through the API: a Rust snippet whose instrumented form doesn't compile now falls back and runs the original (compile.code=0); the normal instrumented path is unchanged. JS/Go/Java smoke runs unaffected.